### PR TITLE
Fix evaluation of return statements

### DIFF
--- a/evaluator.js
+++ b/evaluator.js
@@ -534,7 +534,7 @@ function return_value_content(value) {
 function analyze_return_statement(stmt) {
     const retvalue_func = analyze(return_statement_expression(stmt));
     return (env, succeed, fail) => {
-        succeed(make_return_value(retvalue_func(env)), fail);
+        retvalue_func(env, succeed, fail);
     };
 }
 


### PR DESCRIPTION
Fixes #1 

When we analyze the sub-expression in a return statement, we obtain a function that
expects three arguments: the environment, success and failure continuations.

Let's pass the correct number of arguments when we apply this function, so that
return statements can be correctly evaluated.