### PR TITLE
Extend try-again to return a value

### DIFF
--- a/evaluator.js
+++ b/evaluator.js
@@ -429,7 +429,7 @@ function get_args(arg_funcs, env, succeed, fail) {
 // primitive functions (which are evaluated using the
 // underlying JavaScript), and compound functions.
 
-// Just like deterministic Source, 
+// Just like deterministic Source,
 // application of compound functions is done by evaluating the
 // body of the function with respect to an
 // environment that results from extending the function
@@ -844,7 +844,10 @@ function parse_and_eval(input) {
         (val, next_alternative) => {
             final_result = val;
             display(output_prompt + user_print(val));
-            try_again = next_alternative;
+            try_again = () => {
+              next_alternative();
+              return final_result;
+            };
         },
         () => {
             final_result = null;

--- a/evaluator.js
+++ b/evaluator.js
@@ -844,6 +844,9 @@ function parse_and_eval(input) {
         (val, next_alternative) => {
             final_result = val;
             display(output_prompt + user_print(val));
+
+            // assign a function to try_again so that when called,
+            // the result value is returned
             try_again = () => {
               next_alternative();
               return final_result;

--- a/test.js
+++ b/test.js
@@ -70,7 +70,7 @@ function test_nondet_infinite() {
 
     for (let i = 1; i <= 10; i=i+1) {
         assert_equal(i, final_result);
-        try_again();
+        final_result = try_again();
     }
 }
 
@@ -90,11 +90,11 @@ function test_nondet_require() {
     );
 
     assert_equal(1, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(6, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(12, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(null, final_result);
 }
 
@@ -105,17 +105,17 @@ function test_nondet_combinations() {
     parse_and_eval("list(amb(1, 2, 3), amb('a', 'b'));");
 
     assert_equal(list(1, "a"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(1, "b"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(2, "a"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(2, "b"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(3, "a"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(3, "b"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(null, final_result);
 }
 
@@ -129,7 +129,7 @@ function test_nondet_undo() {
     ");
 
     assert_equal(10, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(5, final_result);
 }
 


### PR DESCRIPTION
add #17 

In the success continuation, instead of assigning the `next_alternative` function to `try_again`, an anonymous function is assigned which calls `next_alternative` and returns the result.

The tests are also updated to make use of new values being returned by calling `try_again`. While not necessary, this serves to test the above functionality with the existing tests.