### PR TITLE
Use try_again value directly

### DIFF
--- a/evaluator.js
+++ b/evaluator.js
@@ -429,7 +429,7 @@ function get_args(arg_funcs, env, succeed, fail) {
 // primitive functions (which are evaluated using the
 // underlying JavaScript), and compound functions.
 
-// Just like deterministic Source, 
+// Just like deterministic Source,
 // application of compound functions is done by evaluating the
 // body of the function with respect to an
 // environment that results from extending the function
@@ -844,7 +844,10 @@ function parse_and_eval(input) {
         (val, next_alternative) => {
             final_result = val;
             display(output_prompt + user_print(val));
-            try_again = next_alternative;
+            try_again = () => {
+              next_alternative();
+              return final_result;
+            };
         },
         () => {
             final_result = null;

--- a/evaluator.js
+++ b/evaluator.js
@@ -844,6 +844,9 @@ function parse_and_eval(input) {
         (val, next_alternative) => {
             final_result = val;
             display(output_prompt + user_print(val));
+
+            // assign a function to try_again so that when called,
+            // the result value is returned
             try_again = () => {
               next_alternative();
               return final_result;

--- a/test.js
+++ b/test.js
@@ -70,7 +70,7 @@ function test_nondet_infinite() {
 
     for (let i = 1; i <= 10; i=i+1) {
         assert_equal(i, final_result);
-        try_again();
+        final_result = try_again();
     }
 }
 
@@ -90,11 +90,11 @@ function test_nondet_require() {
     );
 
     assert_equal(1, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(6, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(12, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(null, final_result);
 }
 
@@ -105,17 +105,17 @@ function test_nondet_combinations() {
     parse_and_eval("list(amb(1, 2, 3), amb('a', 'b'));");
 
     assert_equal(list(1, "a"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(1, "b"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(2, "a"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(2, "b"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(3, "a"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(list(3, "b"), final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(null, final_result);
 }
 
@@ -129,7 +129,7 @@ function test_nondet_undo() {
     ");
 
     assert_equal(10, final_result);
-    try_again();
+    final_result = try_again();
     assert_equal(5, final_result);
 }
 

--- a/test.js
+++ b/test.js
@@ -3,31 +3,31 @@
 /* 1.1 Test Deterministic Functionality */
 
 function test_self_evaluating() {
-	parse_and_eval("4;");
-	assert_equal(4, final_result);
+    parse_and_eval("4;");
+    assert_equal(4, final_result);
 }
 
 function test_assignment() {
-	parse_and_eval("const a = 23; a;");
-	assert_equal(23, final_result);
+    parse_and_eval("const a = 23; a;");
+    assert_equal(23, final_result);
 }
 
 function test_conditional_expressions() {
-	parse_and_eval("100 % 2 === 0 ? true: false;");
-	assert_equal(true, final_result);
+    parse_and_eval("100 % 2 === 0 ? true: false;");
+    assert_equal(true, final_result);
 
-	parse_and_eval("100 % 2 !== 0 ? true: false;");
-	assert_equal(false, final_result);
+    parse_and_eval("100 % 2 !== 0 ? true: false;");
+    assert_equal(false, final_result);
 }
 
 function test_function() {
-	parse_and_eval("const f = () => (x, y) => x + y; f()(12, 13);");
-	assert_equal(25, final_result);
+    parse_and_eval("const f = () => (x, y) => x + y; f()(12, 13);");
+    assert_equal(25, final_result);
 }
 
 function test_subfunction() {
-	parse_and_eval("function f(x) { function g(y) { return y * 2; } return x * g(10); } f(6);");
-	assert_equal(120, final_result);
+    parse_and_eval("function f(x) { function g(y) { return y * 2; } return x * g(10); } f(6);");
+    assert_equal(120, final_result);
 }
 
 function test_binary_boolean_operations() {
@@ -90,12 +90,9 @@ function test_nondet_require() {
     );
 
     assert_equal(1, final_result);
-    final_result = try_again();
-    assert_equal(6, final_result);
-    final_result = try_again();
-    assert_equal(12, final_result);
-    final_result = try_again();
-    assert_equal(null, final_result);
+    assert_equal(6, try_again());
+    assert_equal(12, try_again());
+    assert_equal(null, try_again());
 }
 
 /**
@@ -105,18 +102,12 @@ function test_nondet_combinations() {
     parse_and_eval("list(amb(1, 2, 3), amb('a', 'b'));");
 
     assert_equal(list(1, "a"), final_result);
-    final_result = try_again();
-    assert_equal(list(1, "b"), final_result);
-    final_result = try_again();
-    assert_equal(list(2, "a"), final_result);
-    final_result = try_again();
-    assert_equal(list(2, "b"), final_result);
-    final_result = try_again();
-    assert_equal(list(3, "a"), final_result);
-    final_result = try_again();
-    assert_equal(list(3, "b"), final_result);
-    final_result = try_again();
-    assert_equal(null, final_result);
+    assert_equal(list(1, "b"), try_again());
+    assert_equal(list(2, "a"), try_again());
+    assert_equal(list(2, "b"), try_again());
+    assert_equal(list(3, "a"), try_again());
+    assert_equal(list(3, "b"), try_again());
+    assert_equal(null, try_again());
 }
 
 /**
@@ -135,10 +126,10 @@ function test_nondet_undo() {
 
 run(
     list(
-    	test_self_evaluating,
-    	test_assignment,
-    	test_conditional_expressions,
-    	test_function,
+        test_self_evaluating,
+        test_assignment,
+        test_conditional_expressions,
+        test_function,
         test_subfunction,
         test_shortcircuiting,
         test_nondet_empty,


### PR DESCRIPTION
In the tests, despite `try_again` being able to return a value, its result is stored in `final_result` before being used in `assert_equal`. This adds unnecessary code, `try_again` can be called directly where its value is needed.